### PR TITLE
Fix Apache proxy config and baseUrlPath for team2f25 (by Louie Sanchez)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,5 @@ CMD streamlit run streamlit_app.py \
     --server.headless=true \
     --server.enableCORS=false \
     --server.enableXsrfProtection=false \
-    --browser.gatherUsageStats=false
-
+    --browser.gatherUsageStats=false \
+    --server.baseUrlPath=/team2f25

--- a/apache/team2.conf
+++ b/apache/team2.conf
@@ -41,11 +41,11 @@ RewriteRule ^/team2f25/jupyter/(.*) ws://team2-jupyter:8888/team2f25/jupyter/$1 
 
 # STREAMLIT Configuration (served under /team2f25/)
 # Important: This must come AFTER Jupyter to avoid conflicts
-ProxyPass /team2f25/ http://team2-app:2502/
-ProxyPassReverse /team2f25/ http://team2-app:2502/
+ProxyPass        /team2f25/ http://team2-app:2502/team2f25/
+ProxyPassReverse /team2f25/ http://team2-app:2502/team2f25/
 
 # Streamlit WebSocket support (exclude jupyter paths)
 RewriteCond %{HTTP:Upgrade} =websocket [NC]
 RewriteCond %{REQUEST_URI} ^/team2f25/ [NC]
 RewriteCond %{REQUEST_URI} !^/team2f25/jupyter/ [NC]
-RewriteRule ^/team2f25/(.*) ws://team2-app:2502/$1 [P,L]
+RewriteRule ^/team2f25/(.*) ws://team2-app:2502/team2f25/$1 [P,L]


### PR DESCRIPTION
Updated Apache config to correctly proxy Streamlit under /team2f25/.

Adjusted ProxyPass and ProxyPassReverse directives to include /team2f25/ subpath.

Updated Dockerfile to set --server.baseUrlPath=/team2f25.

Ensures Streamlit and Jupyter apps don’t conflict when served behind Apache.

This fixes routing issues where Streamlit wasn’t accessible under the /team2f25 path.